### PR TITLE
If V3IO_FILE_PATH isn't set, default to /etc/v3io/v3io.yaml

### DIFF
--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -155,7 +155,7 @@ func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*t
 	// Initialize V3IO Adapter
 	cfgpath := os.Getenv("V3IO_FILE_PATH")
 	if cfgpath == "" {
-		cfgpath = "v3io.yaml"
+		cfgpath = "/etc/v3io/v3io.yaml"
 	}
 	cfg, err := config.LoadConfig(cfgpath)
 	if err != nil {

--- a/storage/tsdb/tsdb.go
+++ b/storage/tsdb/tsdb.go
@@ -155,7 +155,7 @@ func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*t
 	// Initialize V3IO Adapter
 	cfgpath := os.Getenv("V3IO_FILE_PATH")
 	if cfgpath == "" {
-		cfgpath = "/etc/v3io/v3io.yaml"
+		cfgpath = "/etc/v3io/v3io-tsdb.yaml"
 	}
 	cfg, err := config.LoadConfig(cfgpath)
 	if err != nil {


### PR DESCRIPTION
This defaults to "/etc/v3io/v3io.yaml" (instead of "v3io.yaml"). In case the configuration doesn't exist. This allows us to use the stable prometheus helm chart rather than forking it / maintaining a copy. 