### PR TITLE
Fix client side aggregations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: go
 
 go:
 - 1.10.x
-- 1.x
 
 go_import_path: github.com/prometheus/prometheus
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ STATICCHECK_IGNORE = \
   github.com/prometheus/prometheus/pkg/textparse/lex.l.go:SA4006 \
   github.com/prometheus/prometheus/pkg/pool/pool.go:SA6002 \
   github.com/prometheus/prometheus/promql/engine.go:SA6002 \
+  github.com/prometheus/prometheus/promql/v3io.go:SA6002 \
   github.com/prometheus/prometheus/web/web.go:SA1019
 
 all: format staticcheck unused build test

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -681,3 +681,18 @@ func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
 		return nil
 	}
 }
+
+// Uname for any platform other than linux.
+func Uname() string {
+	return "(" + runtime.GOOS + ")"
+}
+
+// FdLimits returns the soft and hard limits for file descriptors
+func FdLimits() string {
+	flimit := syscall.Rlimit{}
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &flimit)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("(soft=%d, hard=%d)", flimit.Cur, flimit.Max)
+}

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -681,18 +681,3 @@ func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
 		return nil
 	}
 }
-
-// Uname for any platform other than linux.
-func Uname() string {
-	return "(" + runtime.GOOS + ")"
-}
-
-// FdLimits returns the soft and hard limits for file descriptors
-func FdLimits() string {
-	flimit := syscall.Rlimit{}
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &flimit)
-	if err != nil {
-		return ""
-	}
-	return fmt.Sprintf("(soft=%d, hard=%d)", flimit.Cur, flimit.Max)
-}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -699,8 +699,13 @@ func (ev *evaluator) eval(expr Expr) Value {
 
 	switch e := expr.(type) {
 	case *AggregateExpr:
-		Vector := ev.evalVector(e.Expr)
-		return ev.aggregation(e.Op, e.Grouping, e.Without, e.Param, Vector)
+
+		// @@@v3io
+		// Removed aggregations performed by Prometheus since the storage takes care
+		// of that (sum, avg, count). This was harmless for some aggregations (e.g.
+		// running a sum on a returned sum), but bad for others (counting a count result,
+		// which always returned 1). Simply return the vector as returned by storage (v3io)
+		return ev.evalVector(e.Expr)
 
 	case *BinaryExpr:
 		lhs := ev.evalOneOf(e.LHS, ValueTypeScalar, ValueTypeVector)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -702,13 +702,8 @@ func (ev *evaluator) eval(expr Expr) Value {
 
 	switch e := expr.(type) {
 	case *AggregateExpr:
-
-		// @@@v3io
-		// Removed aggregations performed by Prometheus since the storage takes care
-		// of that (sum, avg, count). This was harmless for some aggregations (e.g.
-		// running a sum on a returned sum), but bad for others (counting a count result,
-		// which always returned 1). Simply return the vector as returned by storage (v3io)
-		return ev.evalVector(e.Expr)
+		Vector := ev.evalVector(e.Expr)
+		return ev.aggregation(e.Op, e.Grouping, e.Without, e.Param, Vector)
 
 	case *BinaryExpr:
 		lhs := ev.evalOneOf(e.LHS, ValueTypeScalar, ValueTypeVector)

--- a/promql/v3io.go
+++ b/promql/v3io.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Build this module only if tests are being run
-// +build test
+// Don't build this module when running tests
+// +build !test
 
 package promql
 

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/aggregate/iterator.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/aggregate/iterator.go
@@ -39,13 +39,10 @@ type AggregateSeries struct {
 
 func NewAggregateSeries(functions, col string, buckets int, interval, rollupTime int64, windows []int) (*AggregateSeries, error) {
 
-	if functions == "" || interval == 0 {
-		return nil, nil
-	}
-
 	split := strings.Split(functions, ",")
 	var aggrMask AggrType
 	var aggrList []AggrType
+
 	for _, s := range split {
 		aggr, ok := aggrTypeString[s]
 		if !ok {
@@ -56,8 +53,14 @@ func NewAggregateSeries(functions, col string, buckets int, interval, rollupTime
 	}
 
 	newAggregateSeries := AggregateSeries{
-		aggrMask: aggrMask, functions: aggrList, colName: col, buckets: buckets, rollupTime: rollupTime,
-		interval: interval, overlapWindows: windows}
+		aggrMask: aggrMask,
+		functions: aggrList,
+		colName: col,
+		buckets: buckets,
+		rollupTime: rollupTime,
+		interval: interval,
+		overlapWindows: windows,
+	}
 
 	return &newAggregateSeries, nil
 }
@@ -319,11 +322,13 @@ func (as *AggregateSet) GetCellValue(aggr AggrType, cell int) (float64, bool) {
 // get the time per aggregate cell
 func (as *AggregateSet) GetCellTime(base int64, index int) int64 {
 	if as.overlapWin == nil {
-		return base + int64(index)*as.interval
+		return base + int64(index) * as.interval
 	}
+
 	if index >= len(as.overlapWin) {
 		return base
 	}
+
 	return base - int64(as.overlapWin[index])*as.interval
 }
 

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/aggregate/iterator.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/aggregate/iterator.go
@@ -53,12 +53,12 @@ func NewAggregateSeries(functions, col string, buckets int, interval, rollupTime
 	}
 
 	newAggregateSeries := AggregateSeries{
-		aggrMask: aggrMask,
-		functions: aggrList,
-		colName: col,
-		buckets: buckets,
-		rollupTime: rollupTime,
-		interval: interval,
+		aggrMask:       aggrMask,
+		functions:      aggrList,
+		colName:        col,
+		buckets:        buckets,
+		rollupTime:     rollupTime,
+		interval:       interval,
 		overlapWindows: windows,
 	}
 
@@ -322,7 +322,7 @@ func (as *AggregateSet) GetCellValue(aggr AggrType, cell int) (float64, bool) {
 // get the time per aggregate cell
 func (as *AggregateSet) GetCellTime(base int64, index int) int64 {
 	if as.overlapWin == nil {
-		return base + int64(index) * as.interval
+		return base + int64(index)*as.interval
 	}
 
 	if index >= len(as.overlapWin) {

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/aggregate/iterator.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/aggregate/iterator.go
@@ -157,7 +157,7 @@ func (as *AggregateSeries) NewSetFromAttrs(
 		}
 
 		i++
-		arrayIndex = (arrayIndex + 1) % as.buckets
+		arrayIndex = (arrayIndex + 1) % (as.buckets + 1)
 	}
 
 	return &aggrSet, nil

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/appender/appender.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/appender/appender.go
@@ -251,10 +251,9 @@ func (mc *MetricsCache) WaitForCompletion(timeout time.Duration) (int, error) {
 	} else if timeout > 0 {
 		maxWaitTime = timeout
 	} else {
-		maxWaitTime = time.Duration(mc.cfg.DefaultTimeout) * time.Second
+		// if negative - use default value from configuration
+		maxWaitTime = time.Duration(mc.cfg.DefaultTimeoutInSeconds) * time.Second
 	}
-
-	//fmt.Printf("\nmaxWaitTime=%d\n", maxWaitTime)
 
 	select {
 	case res := <-waitChan:

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/querier/series.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/querier/series.go
@@ -222,10 +222,10 @@ func NewAggrSeries(set *V3ioSeriesSet, aggr aggregate.AggrType) *V3ioSeries {
 		// this means we need to copy all the stateful things we need into the iterator (e.g. aggrSet) so that
 		// when it's evaluated, it'll hold the proper pointer
 		newSeries.iter = &aggrSeriesIterator{
-			set: set,
-			aggrSet: set.aggrSet,
+			set:      set,
+			aggrSet:  set.aggrSet,
 			aggrType: aggr,
-			index: -1,
+			index:    -1,
 		}
 	}
 
@@ -247,7 +247,7 @@ func (s *aggrSeriesIterator) Seek(t int64) bool {
 		return true
 	}
 
-	if t > s.set.baseTime + int64(s.aggrSet.GetMaxCell()) * s.set.interval {
+	if t > s.set.baseTime+int64(s.aggrSet.GetMaxCell())*s.set.interval {
 		return false
 	}
 

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/querier/series.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/querier/series.go
@@ -213,16 +213,28 @@ func NewAggrSeries(set *V3ioSeriesSet, aggr aggregate.AggrType) *V3ioSeries {
 	newSeries := V3ioSeries{set: set}
 	lset := append(initLabels(set), utils.Label{Name: "Aggregator", Value: aggr.String()})
 	newSeries.lset = lset
+
 	if set.nullSeries {
 		newSeries.iter = &nullSeriesIterator{}
 	} else {
-		newSeries.iter = &aggrSeriesIterator{set: set, aggrType: aggr, index: -1}
+
+		// `set`, the thing this iterator "iterates" over is stateful - it holds a "current" set and aggrSet.
+		// this means we need to copy all the stateful things we need into the iterator (e.g. aggrSet) so that
+		// when it's evaluated, it'll hold the proper pointer
+		newSeries.iter = &aggrSeriesIterator{
+			set: set,
+			aggrSet: set.aggrSet,
+			aggrType: aggr,
+			index: -1,
+		}
 	}
+
 	return &newSeries
 }
 
 type aggrSeriesIterator struct {
 	set      *V3ioSeriesSet
+	aggrSet  *aggregate.AggregateSet
 	aggrType aggregate.AggrType
 	index    int
 	err      error
@@ -235,7 +247,7 @@ func (s *aggrSeriesIterator) Seek(t int64) bool {
 		return true
 	}
 
-	if t > s.set.baseTime+int64(s.set.aggrSet.GetMaxCell())*s.set.interval {
+	if t > s.set.baseTime + int64(s.aggrSet.GetMaxCell()) * s.set.interval {
 		return false
 	}
 
@@ -245,7 +257,7 @@ func (s *aggrSeriesIterator) Seek(t int64) bool {
 
 // advance to the next time interval/bucket
 func (s *aggrSeriesIterator) Next() bool {
-	if s.index >= s.set.aggrSet.GetMaxCell() {
+	if s.index >= s.aggrSet.GetMaxCell() {
 		return false
 	}
 
@@ -255,8 +267,8 @@ func (s *aggrSeriesIterator) Next() bool {
 
 // return the time & value at the current bucket
 func (s *aggrSeriesIterator) At() (t int64, v float64) {
-	val, _ := s.set.aggrSet.GetCellValue(s.aggrType, s.index)
-	return s.set.aggrSet.GetCellTime(s.set.baseTime, s.index), val
+	val, _ := s.aggrSet.GetCellValue(s.aggrType, s.index)
+	return s.aggrSet.GetCellTime(s.set.baseTime, s.index), val
 }
 
 func (s *aggrSeriesIterator) Err() error { return s.err }

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/querier/seriesset.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/querier/seriesset.go
@@ -144,7 +144,15 @@ func (s *V3ioSeriesSet) Next() bool {
 
 			// create series from raw chunks
 			s.currSeries = NewSeries(s)
-			s.aggrSet = s.aggrSeries.NewSetFromChunks(int((s.maxt-s.mint)/s.interval) + 1)
+
+			// the number of cells is equal to divisor of (maxt-mint) and interval. if there's a
+			// remainder, add a cell
+			numCells := (s.maxt - s.mint) / s.interval
+			if (s.maxt % s.mint) != 0 {
+				numCells++
+			}
+
+			s.aggrSet = s.aggrSeries.NewSetFromChunks(int(numCells))
 			if s.overlapWin != nil {
 				s.chunks2WindowedAggregates()
 			} else {
@@ -164,7 +172,11 @@ func (s *V3ioSeriesSet) chunks2IntervalAggregates() {
 	iter := s.currSeries.Iterator()
 	if iter.Next() {
 		t0, _ := iter.At()
-		s.baseTime = (t0 / s.interval) * s.interval
+
+		// the base time should be the first sample we receive. initially, baseTime is zero
+		if s.baseTime == 0 {
+			s.baseTime = t0
+		}
 
 		for {
 			t, v := iter.At()

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/querier/seriesset.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/querier/seriesset.go
@@ -148,7 +148,7 @@ func (s *V3ioSeriesSet) Next() bool {
 			// the number of cells is equal to divisor of (maxt-mint) and interval. if there's a
 			// remainder, add a cell
 			numCells := (s.maxt - s.mint) / s.interval
-			if (s.maxt % s.mint) != 0 {
+			if (s.maxt%s.mint) != 0 || numCells == 0 {
 				numCells++
 			}
 

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/querier/seriesset.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/querier/seriesset.go
@@ -116,7 +116,7 @@ func (s *V3ioSeriesSet) Next() bool {
 			mint := s.partition.CyclicMinTime(s.mint, maxtUpdate)
 
 			start := s.partition.Time2Bucket(mint)
-			end := s.partition.Time2Bucket(s.maxt + s.interval)
+			end := s.partition.Time2Bucket(s.maxt+s.interval) + 1
 
 			// len of the returned array, cropped at the end in case of cyclic overlap
 			length := int((maxtUpdate-mint)/s.interval) + 2
@@ -146,9 +146,9 @@ func (s *V3ioSeriesSet) Next() bool {
 			s.currSeries = NewSeries(s)
 
 			// the number of cells is equal to divisor of (maxt-mint) and interval. if there's a
-			// remainder, add a cell
+			// remainder or if there are no cells (e.g. diff is smaller than interval), add a cell
 			numCells := (s.maxt - s.mint) / s.interval
-			if (s.maxt%s.mint) != 0 || numCells == 0 {
+			if ((s.maxt-s.mint)%s.interval) != 0 || numCells == 0 {
 				numCells++
 			}
 

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/tsdb/testdata/v3io.yaml.template
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/tsdb/testdata/v3io.yaml.template
@@ -15,7 +15,5 @@ verbose: "warn"
 # Default timeout 10 seconds
 timeout: 10
 
-workers: 8
-
 username: <user name>
 password: <password>

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/tsdb/v3iotsdb_integration_test.go
@@ -196,7 +196,7 @@ func TestQueryData(t *testing.T) {
 				{Time: 1532940510 + 10, Value: 100.4}},
 			from: 1532940510, to: 1532940510 + 11,
 			aggregators: "sum",
-			expected:    map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940000, Value: 701.0}}}},
+			expected:    map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940510, Value: 701.0}}}},
 
 		{desc: "Should ingest and query multiple aggregators", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
@@ -205,8 +205,8 @@ func TestQueryData(t *testing.T) {
 				{Time: 1532940510 + 10, Value: 100.4}},
 			from: 1532940510, to: 1532940510 + 11,
 			aggregators: "sum,count",
-			expected: map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940000, Value: 701.0}},
-				"count": {{Time: 1532940000, Value: 3}}}},
+			expected: map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940510, Value: 701.0}},
+				"count": {{Time: 1532940510, Value: 3}}}},
 
 		{desc: "Should ingest and query with illegal time (switch from and to)", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),

--- a/vendor/github.com/v3io/v3io-tsdb/pkg/tsdbctl/create.go
+++ b/vendor/github.com/v3io/v3io-tsdb/pkg/tsdbctl/create.go
@@ -30,8 +30,15 @@ import (
 	"strconv"
 )
 
-const schemaVersion = 0
-const defaultStorageClass = "local"
+const (
+	schemaVersion               = 0
+	defaultStorageClass         = "local"
+	defaultIngestionRate        = "1/s"
+	defaultRollupInterval       = "1h"
+	defaultShardingBuckets      = 8
+	defaultSampleRetentionHours = 0
+	defaultLayerRetentionTime   = "1y"
+)
 
 type createCommandeer struct {
 	cmd             *cobra.Command
@@ -62,10 +69,10 @@ func newCreateCommandeer(rootCommandeer *RootCommandeer) *createCommandeer {
 
 	cmd.Flags().StringVarP(&commandeer.defaultRollups, "rollups", "r", "",
 		"Default aggregation rollups, comma seperated: count,avg,sum,min,max,stddev")
-	cmd.Flags().StringVarP(&commandeer.rollupInterval, "rollup-interval", "i", "1h", "aggregation interval")
-	cmd.Flags().IntVarP(&commandeer.shardingBuckets, "sharding-buckets", "b", 8, "number of buckets to split key")
-	cmd.Flags().IntVarP(&commandeer.sampleRetention, "sample-retention", "a", 0, "sample retention in hours")
-	cmd.Flags().StringVar(&commandeer.sampleRate, "rate", "12/m", "sample rate")
+	cmd.Flags().StringVarP(&commandeer.rollupInterval, "rollup-interval", "i", defaultRollupInterval, "aggregation interval")
+	cmd.Flags().IntVarP(&commandeer.shardingBuckets, "sharding-buckets", "b", defaultShardingBuckets, "number of buckets to split key")
+	cmd.Flags().IntVarP(&commandeer.sampleRetention, "sample-retention", "a", defaultSampleRetentionHours, "sample retention in hours")
+	cmd.Flags().StringVar(&commandeer.sampleRate, "rate", defaultIngestionRate, "sample rate")
 
 	commandeer.cmd = cmd
 
@@ -103,7 +110,7 @@ func (cc *createCommandeer) create() error {
 		AggregatorsGranularity: cc.rollupInterval,
 		StorageClass:           defaultStorageClass,
 		SampleRetention:        cc.sampleRetention,
-		LayerRetentionTime:     "1y", //TODO
+		LayerRetentionTime:     defaultLayerRetentionTime, //TODO: make configurable
 	}
 
 	tableSchema := config.TableSchema{


### PR DESCRIPTION
1. Vendor TSDB 0.0.9
2. Duplicate promql/engine.go into promql/v3io.go. The former gets built during tests the latter during normal run. Contains a change that disables Prometheus aggregations as this applied an aggregation to the already aggregated data coming in from the storage layer
3. Disabled Go 1.x tests as it now tests with Go 1.11 and fails (unrelated to our changes)