### PR TITLE
Fix grouping (e.g. avg on metric group by some label)

### DIFF
--- a/promql/v3io.go
+++ b/promql/v3io.go
@@ -702,13 +702,8 @@ func (ev *evaluator) eval(expr Expr) Value {
 
 	switch e := expr.(type) {
 	case *AggregateExpr:
-
-		// @@@v3io
-		// Removed aggregations performed by Prometheus since the storage takes care
-		// of that (sum, avg, count). This was harmless for some aggregations (e.g.
-		// running a sum on a returned sum), but bad for others (counting a count result,
-		// which always returned 1). Simply return the vector as returned by storage (v3io)
-		return ev.evalVector(e.Expr)
+		Vector := ev.evalVector(e.Expr)
+		return ev.aggregation(e.Op, e.Grouping, e.Without, e.Param, Vector)
 
 	case *BinaryExpr:
 		lhs := ev.evalOneOf(e.LHS, ValueTypeScalar, ValueTypeVector)
@@ -1264,6 +1259,13 @@ type groupedAggregation struct {
 
 // aggregation evaluates an aggregation operation on a Vector.
 func (ev *evaluator) aggregation(op itemType, grouping []string, without bool, param Expr, vec Vector) Vector {
+
+	// @@@v3io
+	// Removed count aggregations performed by Prometheus since the storage takes care
+	// of that. If we re-count them we will get improper values
+	if op == itemCount || op == itemCountValues {
+		return vec
+	}
 
 	result := map[uint64]*groupedAggregation{}
 	var k int64


### PR DESCRIPTION
In the previous PR, prometheus aggregations were disabled completely. In this PR, only count aggregations are disabled. This fixes:
1. Grouping
2. Some aggregations for some reason (i.e. previously lower resolution aggregations like 1 hour failed to return data - with this fix it seems to work consistently)

I am sure there are still issues around aggregations but this is better than what we have now. 