### PR TITLE
TSDB-78: Fix security issue

### DIFF
--- a/storage/tsdb/v3io.go
+++ b/storage/tsdb/v3io.go
@@ -18,7 +18,6 @@ package tsdb
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"reflect"
 	"sync"
@@ -199,9 +198,7 @@ func (s *ReadyStorage) createV3ioPromAdapater(configPath string) (*promtsdb.V3io
 		return nil, nil
 	}
 
-	if jsonLoadedConfig, err := json.Marshal(&loadedConfig); err == nil {
-		s.logger.Log("msg", "Creating v3io adapter", "config", string(jsonLoadedConfig))
-	}
+	s.logger.Log("msg", "Creating v3io adapter", "config", loadedConfig.String())
 
 	return promtsdb.NewV3ioProm(loadedConfig, nil, nil)
 }


### PR DESCRIPTION
Use sanitized String() method of V3ioConfig

Example output:
```
...
level=info ts=2019-02-27T08:55:08.690570162Z caller=web.go:397 component=web msg="Start listening for connections" address=0.0.0.0:9090
ts=2019-02-27T08:55:08.690611381Z caller=v3io.go:63 component=tsdb msg="Creating initial v3io adapter" configPath=/etc/v3io/v3io-tsdb.yaml
ts=2019-02-27T08:55:08.696983993Z caller=v3io.go:201 component=tsdb msg="Creating v3io adapter" config="{\"webApiEndpoint\":\"192.168.224.173:8081\",\"container\":\"bigdata\",\"tablePath\":\"\",\"username\":\"someuser\",\"password\":\"SANITIZED\",\"accessKey\":\"SANITIZED\",\"logLevel\":\"warn\",\"workers\":1,\"qryWorkers\":1,\"maxBehind\":0,\"overrideOld\":false,\"timeout\":86400,\"batchSize\":64,\"maximumSampleSize\":8,\"maximumPartitionSize\":1700000,\"minimumChunkSize\":200,\"maximumChunkSize\":32000,\"shardingBucketsCount\":8,\"performance\":{\"output\":\"\",\"reportInterval\":0},\"buildInfo\":{}}"
level=info ts=2019-02-27T08:55:08.748432326Z caller=main.go:624 msg="Loading configuration file" filename=/Users/igormakhin/config/prometheus/prometheus.yml
...
```