### PR TITLE
ignore step&aggrWindow when tsdb should not do any aggregations (#78)

### DIFF
--- a/storage/tsdb/promtsdb.go
+++ b/storage/tsdb/promtsdb.go
@@ -140,13 +140,20 @@ func (promQuery *V3ioPromQuerier) Select(params *storage.SelectParams, oms ...*l
 		promQuery.LastTSDBAggregatedAggr = params.Func
 	}
 
+	// In case we can not do aggregations, make sure no step or aggregation window is passed.
+	step,aggrWindow := params.Step, params.AggregationWindow
+	if !promQuery.UseV3ioAggregations(){
+		step = 0
+		aggrWindow = 0
+	}
+
 	selectParams := &pquerier.SelectParams{Name: name,
 		Functions:         function,
-		Step:              params.Step,
+		Step:              step,
 		Filter:            filter,
 		From:              promQuery.mint,
 		To:                promQuery.maxt,
-		AggregationWindow: params.AggregationWindow}
+		AggregationWindow: aggrWindow}
 
 	promQuery.logger.DebugWith("Going to query tsdb", "params", selectParams,
 		"UseAggregates", promQuery.UseAggregates, "UseAggregatesConfig", promQuery.UseAggregatesConfig)


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->