### PR TITLE
fix(CI): use Githubc client for mitigating unstable releases conflicts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ podTemplate(label: "${git_project}-${label}", inheritFrom: "jnlp-docker") {
                 common.notify_slack {
                     stage("build ${git_project} in dood") {
                         container('docker-cmd') {
-                            dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
+                            dir("${BUILD_FOLDER}/src/github.com/${git_project_user}/${git_project}") {
                                 sh("docker build . -f Dockerfile.multi --tag v3io-prom:${github_client.tag.docker}")
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
+
+@Library('pipelinex@development') _
+import com.iguazio.pipelinex.DockerRepo
+
+
 label = "${UUID.randomUUID().toString()}"
 BUILD_FOLDER = "/home/jenkins/go"
 git_project = "prometheus"
@@ -10,52 +15,33 @@ podTemplate(label: "${git_project}-${label}", inheritFrom: "jnlp-docker") {
         withCredentials([
                 string(credentialsId: git_deploy_user_token, variable: 'GIT_TOKEN')
         ]) {
+
             def TAG_VERSION
             def DOCKER_TAG_VERSION
-            pipelinex = library(identifier: 'pipelinex@development', retriever: modernSCM(
-                    [$class       : 'GitSCMSource',
-                     credentialsId: git_deploy_user_private_key,
-                     remote       : "git@github.com:iguazio/pipelinex.git"])).com.iguazio.pipelinex
-            multi_credentials = [pipelinex.DockerRepo.ARTIFACTORY_IGUAZIO, pipelinex.DockerRepo.DOCKER_HUB, pipelinex.DockerRepo.QUAY_IO, pipelinex.DockerRepo.GCR_IO]
+            multi_credentials = [DockerRepo.ARTIFACTORY_IGUAZIO, DockerRepo.DOCKER_HUB, DockerRepo.QUAY_IO, DockerRepo.GCR_IO]
 
-            common.notify_slack {
-                stage('get tag data') {
-                    container('jnlp') {
-                        TAG_VERSION = github.get_tag_version(TAG_NAME)
-                        DOCKER_TAG_VERSION = github.get_docker_tag_version(TAG_NAME)
-
-                        echo "$TAG_VERSION"
-                        echo "$DOCKER_TAG_VERSION"
-                    }
-                }
-
-                if (github.check_tag_expiration(git_project, git_project_user, TAG_VERSION, GIT_TOKEN)) {
-                    stage('prepare sources') {
-                        container('jnlp') {
-                            dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
-                                git(changelog: false, credentialsId: git_deploy_user_private_key, poll: false, url: "git@github.com:${git_project_user}/${git_project}.git")
-                                sh("git checkout ${TAG_VERSION}")
+            def github_client = new Githubc(git_project_user, git_project, GIT_TOKEN, env.TAG_NAME, this)
+            github_client.releaseCi(true) {
+                
+                common.notify_slack {
+                        stage("build ${git_project} in dood") {
+                            container('docker-cmd') {
+                                dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
+                                    sh("docker build . -f Dockerfile.multi --tag v3io-prom:${DOCKER_TAG_VERSION}")
+                                }
                             }
                         }
-                    }
 
-                    stage("build ${git_project} in dood") {
-                        container('docker-cmd') {
-                            dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
-                                sh("docker build . -f Dockerfile.multi --tag v3io-prom:${DOCKER_TAG_VERSION}")
+                        stage('push') {
+                            container('docker-cmd') {
+                                dockerx.images_push_multi_registries(["v3io-prom:${DOCKER_TAG_VERSION}"], multi_credentials)
                             }
                         }
-                    }
 
-                    stage('push') {
-                        container('docker-cmd') {
-                            dockerx.images_push_multi_registries(["v3io-prom:${DOCKER_TAG_VERSION}"], multi_credentials)
-                        }
-                    }
-
-                    stage('update release status') {
-                        container('jnlp') {
-                            github.update_release_status(git_project, git_project_user, "${TAG_VERSION}", GIT_TOKEN)
+                        stage('update release status') {
+                            container('jnlp') {
+                                github.update_release_status(git_project, git_project_user, "${TAG_VERSION}", GIT_TOKEN)
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,26 +22,19 @@ podTemplate(label: "${git_project}-${label}", inheritFrom: "jnlp-docker") {
 
             def github_client = new Githubc(git_project_user, git_project, GIT_TOKEN, env.TAG_NAME, this)
             github_client.releaseCi(true) {
-                
+
                 common.notify_slack {
-                        stage("build ${git_project} in dood") {
-                            container('docker-cmd') {
-                                dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
-                                    sh("docker build . -f Dockerfile.multi --tag v3io-prom:${DOCKER_TAG_VERSION}")
-                                }
+                    stage("build ${git_project} in dood") {
+                        container('docker-cmd') {
+                            dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
+                                sh("docker build . -f Dockerfile.multi --tag v3io-prom:${DOCKER_TAG_VERSION}")
                             }
                         }
+                    }
 
-                        stage('push') {
-                            container('docker-cmd') {
-                                dockerx.images_push_multi_registries(["v3io-prom:${DOCKER_TAG_VERSION}"], multi_credentials)
-                            }
-                        }
-
-                        stage('update release status') {
-                            container('jnlp') {
-                                github.update_release_status(git_project, git_project_user, "${TAG_VERSION}", GIT_TOKEN)
-                            }
+                    stage('push') {
+                        container('docker-cmd') {
+                            dockerx.images_push_multi_registries(["v3io-prom:${DOCKER_TAG_VERSION}"], multi_credentials)
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,6 @@ podTemplate(label: "${git_project}-${label}", inheritFrom: "jnlp-docker") {
                 string(credentialsId: git_deploy_user_token, variable: 'GIT_TOKEN')
         ]) {
 
-            def TAG_VERSION
-            def DOCKER_TAG_VERSION
             multi_credentials = [DockerRepo.ARTIFACTORY_IGUAZIO, DockerRepo.DOCKER_HUB, DockerRepo.QUAY_IO, DockerRepo.GCR_IO]
 
             def github_client = new Githubc(git_project_user, git_project, GIT_TOKEN, env.TAG_NAME, this)
@@ -27,14 +25,14 @@ podTemplate(label: "${git_project}-${label}", inheritFrom: "jnlp-docker") {
                     stage("build ${git_project} in dood") {
                         container('docker-cmd') {
                             dir("${BUILD_FOLDER}/src/github.com/${git_project}/${git_project}") {
-                                sh("docker build . -f Dockerfile.multi --tag v3io-prom:${DOCKER_TAG_VERSION}")
+                                sh("docker build . -f Dockerfile.multi --tag v3io-prom:${github_client.tag.docker}")
                             }
                         }
                     }
 
                     stage('push') {
                         container('docker-cmd') {
-                            dockerx.images_push_multi_registries(["v3io-prom:${DOCKER_TAG_VERSION}"], multi_credentials)
+                            dockerx.images_push_multi_registries(["v3io-prom:${github_client.tag.docker}"], multi_credentials)
                         }
                     }
                 }


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->