### PR TITLE
disable config watch

### DIFF
--- a/storage/tsdb/v3io.go
+++ b/storage/tsdb/v3io.go
@@ -93,11 +93,11 @@ func (s *ReadyStorage) Set(db *tsdb.DB, startTimeMargin int64) {
 	s.v3ioConfig = v3ioConfig
 
 	// watch configuration file for changes
-	s.watchConfigForChanges(configPath)
+	/*s.watchConfigForChanges(configPath)
 	if err != nil {
 		s.error = errors.Wrap(err, "failed to start config watch")
 		return
-	}
+	}*/
 
 	s.error = nil
 }


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->