### PR TITLE
Set logger format to json

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -256,6 +256,11 @@ func main() {
 		os.Exit(2)
 	}
 
+	err = cfg.promlogConfig.Format.Set("json")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "could not set log format json"))
+		os.Exit(2)
+	}
 	logger := promlog.New(&cfg.promlogConfig)
 
 	cfg.web.ExternalURL, err = computeExternalURL(cfg.prometheusURL, cfg.web.ListenAddress)


### PR DESCRIPTION
Set flag `promlogConfig.Format` to be always json and use json_logger.
This change makes to logs easy to parse and friendly to use and read with filebeat and elasticsearch.
Also added log levels where missing.